### PR TITLE
[proposal] search by supply

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -100,11 +100,24 @@ function getSearchWhere(search: string, or?: boolean) {
       terms.reduce((prev, current) => {
         const [key, condition, value] = current.split(':');
         const isBoolean = ['true', 'false'].includes(value);
-        const mode =
+        let mode =
           isBoolean || ['in', 'notIn'].includes(condition)
             ? undefined
             : 'insensitive';
-        const parsedValue = isBoolean ? value === 'true' : value;
+        let parsedValue: string | boolean | { supply: { name: string } } =
+          value;
+
+        if (isBoolean) {
+          parsedValue = value === 'true';
+        }
+
+        // shelterSupplies.some.foo
+        if (key === 'shelterSupplies') {
+          parsedValue = {
+            supply: { name: value },
+          };
+          mode = undefined;
+        }
 
         return {
           ...prev,


### PR DESCRIPTION
Acredito que muitas pessoas pesquisem por suprimento ao invés de nome e endereço.

Essa PR implementa busca por suprimento no backend. Usei esse curl pra testar, teria que adaptar o front.

`curl 'http://localhost:3000/shelters?orderBy=prioritySum&order=desc&search=shelterSupplies:some:bla'`
