### PR TITLE
Adicionar docker compose para ambiente de DEV

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  api:
+    container_name: sos-rs-api
+    image: node:18.18
+    restart: always
+    tty: true
+    depends_on:
+      - db
+    ports:
+      - "4000:4000"
+    volumes:
+      - .:/usr/app
+    working_dir: "/usr/app"
+    environment:
+      - DB_HOST=sos-rs-db
+      - DB_PORT=5432
+      - DB_DATABASE_NAME=sos_rs
+      - DB_USER=root
+      - DB_PASSWORD=root
+    command: >
+      sh -c "npm install &&
+      npx prisma generate &&
+      npx prisma migrate dev &&
+      npm run start:dev"
+  db:
+    container_name: sos-rs-db
+    image: postgres
+    environment:
+      - POSTGRES_PASSWORD=root
+      - POSTGRES_USER=root


### PR DESCRIPTION
Criei o arquivo `docker-compose.dev.yml` para facilitar para os novos desenvolvedores que queiram contribuir com o projeto. O arquivo compose já cria o container da API e do banco de dados Postgres junto.

Para rodar ele, precisa especificar o nome do arquivo: `docker compose -f docker-compose.dev.yml up -d`