### PR TITLE
Tornando a busca de abrigos por endereço ou nome case insensitive

### DIFF
--- a/src/shelter/shelter.service.ts
+++ b/src/shelter/shelter.service.ts
@@ -222,8 +222,8 @@ export class ShelterService {
       AND: [
         {
           OR: [
-            { address: { contains: payload.search } },
-            { name: { contains: payload.search } },
+            { address: { contains: payload.search, mode: 'insensitive' } },
+            { name: { contains: payload.search, mode: 'insensitive' } },
           ],
         },
       ],


### PR DESCRIPTION
- Adicionada condição na query para tornar a busca do abrigo case insensitive

Ao buscar pelo termo "esperança" nada foi encontrado
<img width="953" alt="image" src="https://github.com/SOS-RS/backend/assets/59173445/8d24305a-f7ab-4464-8f2c-7e0c4ecfcad1">

Mas buscando por "Esperança" o resultado é retornado
<img width="953" alt="image" src="https://github.com/SOS-RS/backend/assets/59173445/e3667b53-72ad-48c6-a49e-4d54c4e59aef">

