### PR TITLE
fix: Remove 'UnderControl' supplies from shelter queries

### DIFF
--- a/src/shelter/shelter.service.ts
+++ b/src/shelter/shelter.service.ts
@@ -10,6 +10,7 @@ import {
   UpdateShelterSchema,
 } from './types';
 import { SeachQueryProps } from '@/decorators/search-query/types';
+import { SupplyPriority } from 'src/supply/types';
 
 @Injectable()
 export class ShelterService {
@@ -70,6 +71,11 @@ export class ShelterService {
         latitude: true,
         longitude: true,
         shelterSupplies: {
+          where: {
+            priority: {
+              gt: SupplyPriority.UnderControl,
+            },
+          },
           select: {
             priority: true,
             supply: {
@@ -119,6 +125,11 @@ export class ShelterService {
           createdAt: true,
           updatedAt: true,
           shelterSupplies: {
+            where: {
+              priority: {
+                gt: SupplyPriority.UnderControl,
+              },
+            },
             select: {
               priority: true,
               supply: {
@@ -193,6 +204,11 @@ export class ShelterService {
         createdAt: true,
         updatedAt: true,
         shelterSupplies: {
+          where: {
+            priority: {
+              gt: SupplyPriority.UnderControl,
+            },
+          },
           select: {
             priority: true,
             supply: {


### PR DESCRIPTION
## Descrição:
 - Esse PR irá:
    -  [🐛 Remove 'UnderControl' supplies from shelter queries](https://github.com/SOS-RS/backend/commit/5b9c29538e90b36de96e8addd6cee13a10112863)
    - Basicamente, remove os itens 'não preciso' da home/lobby do shelter.

