### PR TITLE
[develop] ZodError no cadastro do abrigo

### DIFF
--- a/src/shelter/types.ts
+++ b/src/shelter/types.ts
@@ -54,6 +54,7 @@ const CreateShelterSchema = ShelterSchema.omit({
   id: true,
   createdAt: true,
   updatedAt: true,
+  verified: true,
 });
 
 const UpdateShelterSchema = ShelterSchema.pick({


### PR DESCRIPTION
![image](https://github.com/SOS-RS/backend/assets/22968607/d7ebe176-3644-4d64-8a4e-824bf249806b)

## Descrição
Ao tentar cadastrar um abrigo é apresentado um erro de validação

## Passos para replicação
1. Entrar no painel admin
2. [Logue no sistema](http://127.0.0.1:5173/entrar) `/entrar`
3. [Ir em cadastrar abrigo](http://127.0.0.1:5173/abrigo/cadastrar) `abrigo/cadastrar`
4. Preencha os dados necessários
5. Clique em cadastrar
6. Deve aparecer um `ZodError`

## Correção
Foi notado que no schema o default para `verified` está setado para false mas o problema está no zod para criação, ele verifica o campo(é necessário enviar o `verified`).

Portanto a solução foi deixar o omit de verified na criação.