### PR TITLE
feat: add `top` endpoint to supplies

### DIFF
--- a/src/supply/supply.controller.ts
+++ b/src/supply/supply.controller.ts
@@ -1,10 +1,12 @@
 import {
   Body,
   Controller,
+  DefaultValuePipe,
   Get,
   HttpException,
   Logger,
   Param,
+  ParseIntPipe,
   Post,
   Put,
   Query,
@@ -33,15 +35,12 @@ export class SupplyController {
   }
 
   @Get('top')
-  async top(@Query('limit') limit: number = 10, @Query('skip') skip: number) {
+  async top(
+    @Query('perPage', new DefaultValuePipe(10), ParseIntPipe) perPage: number,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+  ) {
     try {
-      if (limit && typeof limit === 'string') {
-        limit = Number.parseInt(limit);
-      }
-      if (skip && typeof skip === 'string') {
-        skip = Number.parseInt(skip);
-      }
-      const data = await this.supplyServices.top(limit, skip);
+      const data = await this.supplyServices.top({ perPage, page });
       return new ServerResponse(200, 'Successfully get top supplies', data);
     } catch (err: any) {
       this.logger.error(`Failed to get supplies: ${err}`);

--- a/src/supply/supply.controller.ts
+++ b/src/supply/supply.controller.ts
@@ -38,9 +38,10 @@ export class SupplyController {
   async top(
     @Query('perPage', new DefaultValuePipe(10), ParseIntPipe) perPage: number,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('shelterId') shelterId: string,
   ) {
     try {
-      const data = await this.supplyServices.top({ perPage, page });
+      const data = await this.supplyServices.top({ perPage, page, shelterId });
       return new ServerResponse(200, 'Successfully get top supplies', data);
     } catch (err: any) {
       this.logger.error(`Failed to get supplies: ${err}`);

--- a/src/supply/supply.controller.ts
+++ b/src/supply/supply.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Post,
   Put,
+  Query,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
@@ -25,6 +26,23 @@ export class SupplyController {
     try {
       const data = await this.supplyServices.index();
       return new ServerResponse(200, 'Successfully get supplies', data);
+    } catch (err: any) {
+      this.logger.error(`Failed to get supplies: ${err}`);
+      throw new HttpException(err?.code ?? err?.name ?? `${err}`, 400);
+    }
+  }
+
+  @Get('top')
+  async top(@Query('limit') limit: number = 10, @Query('skip') skip: number) {
+    try {
+      if (limit && typeof limit === 'string') {
+        limit = Number.parseInt(limit);
+      }
+      if (skip && typeof skip === 'string') {
+        skip = Number.parseInt(skip);
+      }
+      const data = await this.supplyServices.top(limit, skip);
+      return new ServerResponse(200, 'Successfully get top supplies', data);
     } catch (err: any) {
       this.logger.error(`Failed to get supplies: ${err}`);
       throw new HttpException(err?.code ?? err?.name ?? `${err}`, 400);

--- a/src/supply/supply.service.ts
+++ b/src/supply/supply.service.ts
@@ -2,7 +2,11 @@ import z from 'zod';
 import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '../prisma/prisma.service';
-import { CreateSupplySchema, UpdateSupplySchema } from './types';
+import {
+  CreateSupplySchema,
+  SupplySearchSchema,
+  UpdateSupplySchema,
+} from './types';
 
 @Injectable()
 export class SupplyService {
@@ -54,7 +58,11 @@ export class SupplyService {
     return data;
   }
 
-  async top(top: number = 10, skip: number = 0) {
+  async top(body: z.infer<typeof SupplySearchSchema>) {
+    const payload = SupplySearchSchema.parse(body);
+    const take = payload.perPage;
+    const skip = payload.perPage * (payload.page - 1);
+
     const data = await this.prismaService.supply.groupBy({
       by: ['name'],
       _count: {
@@ -65,8 +73,8 @@ export class SupplyService {
           name: 'desc',
         },
       },
-      skip: skip ?? 0,
-      take: top ?? 10,
+      take,
+      skip,
     });
 
     return data.map((row) => ({ name: row.name, amount: row._count.name }));

--- a/src/supply/supply.service.ts
+++ b/src/supply/supply.service.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
 import { Injectable } from '@nestjs/common';
-
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import {
   CreateSupplySchema,
@@ -63,20 +63,18 @@ export class SupplyService {
     const take = payload.perPage;
     const skip = payload.perPage * (payload.page - 1);
 
-    const data = await this.prismaService.supply.groupBy({
-      by: ['name'],
-      _count: {
-        name: true,
-      },
-      orderBy: {
-        _count: {
-          name: 'desc',
-        },
-      },
-      take,
-      skip,
-    });
+    const query = Prisma.sql`SELECT name, count(*)::int as amount
+    FROM shelter_supplies
+    LEFT JOIN supplies ON shelter_supplies.supply_id = supplies.id
+    ${
+      payload.shelterId
+        ? Prisma.sql`WHERE shelter_id = ${payload.shelterId}`
+        : Prisma.empty
+    }
+    GROUP BY name
+    ORDER BY amount DESC
+    LIMIT ${take} OFFSET ${skip}`;
 
-    return data.map((row) => ({ name: row.name, amount: row._count.name }));
+    return await this.prismaService.$queryRaw(query);
   }
 }

--- a/src/supply/supply.service.ts
+++ b/src/supply/supply.service.ts
@@ -53,4 +53,22 @@ export class SupplyService {
 
     return data;
   }
+
+  async top(top: number = 10, skip: number = 0) {
+    const data = await this.prismaService.supply.groupBy({
+      by: ['name'],
+      _count: {
+        name: true,
+      },
+      orderBy: {
+        _count: {
+          name: 'desc',
+        },
+      },
+      skip: skip ?? 0,
+      take: top ?? 10,
+    });
+
+    return data.map((row) => ({ name: row.name, amount: row._count.name }));
+  }
 }

--- a/src/supply/types.ts
+++ b/src/supply/types.ts
@@ -16,6 +16,14 @@ const SupplySchema = z.object({
   updatedAt: z.string().nullable().optional(),
 });
 
+const SupplySearchSchema = z.object({
+  page: z.preprocess((v) => +((v ?? '1') as string), z.number().min(1)),
+  perPage: z.preprocess(
+    (v) => +((v ?? '10') as string),
+    z.number().min(1).max(100),
+  ),
+});
+
 const CreateSupplySchema = SupplySchema.omit({
   id: true,
   createdAt: true,
@@ -27,4 +35,10 @@ const UpdateSupplySchema = SupplySchema.pick({
   supplyCategoryId: true,
 }).partial();
 
-export { SupplySchema, CreateSupplySchema, UpdateSupplySchema, SupplyPriority };
+export {
+  SupplySchema,
+  SupplySearchSchema,
+  CreateSupplySchema,
+  UpdateSupplySchema,
+  SupplyPriority,
+};

--- a/src/supply/types.ts
+++ b/src/supply/types.ts
@@ -17,6 +17,7 @@ const SupplySchema = z.object({
 });
 
 const SupplySearchSchema = z.object({
+  shelterId: z.string().nullable().optional(),
   page: z.preprocess((v) => +((v ?? '1') as string), z.number().min(1)),
   perPage: z.preprocess(
     (v) => +((v ?? '10') as string),


### PR DESCRIPTION
Adicionado o endpoint `/supplies/top` com os parâmetros `page` e `perPage`. 

```
curl 'localhost:4000/supplies/top?perPage=3&page=1'
{
  "statusCode": 200,
  "message": "Successfully get top supplies",
  "data": [
    {
      "name": "1 Notebook pode ser usado",
      "amount": 1
    },
    {
      "name": "Aparelho de barbear",
      "amount": 1
    },
    {
      "name": "Turnos de manhã",
      "amount": 1
    }
  ]
}
```

Em seguida atualizo com o filtro por abrigo.