### PR TITLE
Hotfix priority sum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Check out the source
+      - name: Checkout Source
+        uses: actions/checkout@v4
+      # Setup node.js and cache
+      - name: "Setup node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.x"
+          cache: 'npm'
+          cache-dependency-path: ./package-lock.json
+      # Install dependencies
+      - name: Install dependencies
+        run: npm ci
+      # Lint App
+      - name: Lint App
+        run: npm run lint:ci
+      # Build App
+      - name: Build App
+        run: npm run build 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.18 as node
+FROM node:18.18-alpine as node
 
 WORKDIR /usr/app
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,31 +3,34 @@ version: '3.8'
 services:
   api:
     container_name: sos-rs-api
-    image: node:18.18
+    image: node:18.18-alpine
     restart: always
     tty: true
     depends_on:
       - db
     ports:
-      - '4000:4000'
+      - '${PORT}:${PORT}'
     volumes:
       - .:/usr/app
       - /usr/app/node_modules
     working_dir: '/usr/app'
     environment:
-      - DB_HOST=sos-rs-db
-      - DB_PORT=5432
-      - DB_DATABASE_NAME=sos_rs
-      - DB_USER=root
-      - DB_PASSWORD=root
+      - DB_HOST=${DB_HOST}
+      - DB_PORT=${DB_PORT}
+      - DB_DATABASE_NAME=${DB_DATABASE_NAME}
+      - DB_USER=${DB_USER}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - PORT=${PORT}
     command: >
       sh -c "npm install &&
       npx prisma generate &&
       npx prisma migrate dev &&
-      npm run start:dev"
+      npm run start:dev -- --preserveWatchOutput"
   db:
     container_name: sos-rs-db
     image: postgres
+    ports:
+      - '${DB_PORT}:${DB_PORT}'
     environment:
-      - POSTGRES_PASSWORD=root
-      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+      - POSTGRES_USER=${DB_USER}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint:ci": "eslint \"{src,apps,libs,test}/**/*.ts\" --format=stylish",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/src/shelter-supply/shelter-supply.service.ts
+++ b/src/shelter-supply/shelter-supply.service.ts
@@ -84,6 +84,7 @@ export class ShelterSupplyService {
 
     const supplies = await this.prismaService.shelterSupply.findMany({
       where: {
+        shelterId,
         supplyId: {
           in: ids,
         },
@@ -109,7 +110,7 @@ export class ShelterSupplyService {
       }),
       this.prismaService.shelterSupply.updateMany({
         where: {
-          shelterId: shelterId,
+          shelterId,
           supplyId: {
             in: ids,
           },

--- a/src/shelter-supply/shelter-supply.service.ts
+++ b/src/shelter-supply/shelter-supply.service.ts
@@ -82,18 +82,44 @@ export class ShelterSupplyService {
   async updateMany(body: z.infer<typeof UpdateManyShelterSupplySchema>) {
     const { ids, shelterId } = UpdateManyShelterSupplySchema.parse(body);
 
-    await this.prismaService.shelterSupply.updateMany({
+    const supplies = await this.prismaService.shelterSupply.findMany({
       where: {
-        shelterId: shelterId,
         supplyId: {
           in: ids,
         },
       },
-      data: {
-        priority: SupplyPriority.UnderControl,
-        updatedAt: new Date().toISOString(),
-      },
     });
+
+    const prioritySum = supplies.reduce(
+      (prev, current) => prev + current.priority,
+      0,
+    );
+
+    await this.prismaService.$transaction([
+      this.prismaService.shelter.update({
+        where: {
+          id: shelterId,
+        },
+        data: {
+          prioritySum: {
+            decrement: prioritySum,
+          },
+          updatedAt: new Date().toISOString(),
+        },
+      }),
+      this.prismaService.shelterSupply.updateMany({
+        where: {
+          shelterId: shelterId,
+          supplyId: {
+            in: ids,
+          },
+        },
+        data: {
+          priority: SupplyPriority.UnderControl,
+          updatedAt: new Date().toISOString(),
+        },
+      }),
+    ]);
   }
 
   async index(shelterId: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,8 @@
       "@/guards/*": ["./src/guards/*"],
       "@/guards": ["./src/guards"]
     }
+  },
+  "watchOptions": {
+    "watchFile": "fixedPollingInterval"
   }
 }


### PR DESCRIPTION
Este Pull Request aborda uma inconsistência no mecanismo de atualização para shelter_supplies em lote a partir do endpoint **PUT shelter/supplies/<shelterId>/many** e seus correspondentes shelters.

As atualizações no **shelter_supply.priority** deste endpoint não estavam refletiam no **shelter.priority_sum**, que é crucial para a ordenação dos abrigos por prioridade decrescente. Este descuido poderia levar a ordenações incorretas e agora foi corrigido.

### Alterações

1. Atualizado o método **ShelterSupplyService.updateMany** para garantir que qualquer alteração em **shelter_supply.priority** também acione uma atualização no **shelter.priority_sum** correspondente.
2. Adicionada uma transação para garantir que as atualizações em shelter_supplies e shelters sejam atômicas, evitando atualizações parciais.

### Por que isso é importante?

O **shelter.priority_sum** é um campo derivado usado para ordenar os abrigos com base na prioridade agregada de seus suprimentos. Garantir que este campo seja atualizado precisamente é crucial para manter a integridade dos nossos algoritmos de ordenação e, por extensão, a funcionalidade do sistema que depende dessas ordenações.

### Como testar

Modifique a **priority** de uma ou mais entradas em **shelter_supplies**.
Verifique que o **shelter.priority_sum** correspondente é atualizado corretamente.
Confira a ordenação dos abrigos para garantir que eles refletem as prioridades atualizadas.