### PR TITLE
Somente exibir campo de Contato quando logado(staff ou user)

### DIFF
--- a/src/decorators/UserDecorator/index.ts
+++ b/src/decorators/UserDecorator/index.ts
@@ -1,3 +1,0 @@
-import { UserDecorator } from './user.decorator';
-
-export { UserDecorator };

--- a/src/decorators/UserDecorator/index.ts
+++ b/src/decorators/UserDecorator/index.ts
@@ -1,0 +1,3 @@
+import { UserDecorator } from './user.decorator';
+
+export { UserDecorator };

--- a/src/decorators/UserDecorator/user.decorator.ts
+++ b/src/decorators/UserDecorator/user.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const UserDecorator = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request?.user;
+  },
+);

--- a/src/guards/apply-user.guard.ts
+++ b/src/guards/apply-user.guard.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class ApplyUser extends AuthGuard('jwt') {
+  handleRequest(err: any, user: any) {
+    if (user) return user;
+    return null;
+  }
+}

--- a/src/guards/utils.ts
+++ b/src/guards/utils.ts
@@ -41,4 +41,4 @@ async function isRightSessionRole(
   return false;
 }
 
-export { canActivate, isRightSessionRole };
+export { canActivate };

--- a/src/guards/utils.ts
+++ b/src/guards/utils.ts
@@ -11,22 +11,34 @@ async function canActivate(context: ExecutionContext, allowed: AccessLevel[]) {
   if (request.user) {
     const { userId, sessionId } = request.user;
 
-    const session = await service.session.findUnique({
-      where: { id: sessionId, active: true, user: { id: userId } },
-      include: {
-        user: true,
-      },
-    });
-
-    if (
-      session &&
-      allowed.some((permission) => permission === session.user.accessLevel)
-    ) {
-      return true;
-    }
+    return isRightSessionRole(allowed, sessionId, userId);
   }
 
   return false;
 }
 
-export { canActivate };
+async function isRightSessionRole(
+  allowed: AccessLevel[],
+  sessionId?: string,
+  userId?: string,
+) {
+  if (!sessionId) return false;
+  if (!userId) return false;
+
+  const session = await service.session.findUnique({
+    where: { id: sessionId, active: true, user: { id: userId } },
+    include: {
+      user: true,
+    },
+  });
+
+  if (
+    session &&
+    allowed.some((permission) => permission === session.user.accessLevel)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export { canActivate, isRightSessionRole };

--- a/src/shelter/shelter.controller.ts
+++ b/src/shelter/shelter.controller.ts
@@ -16,7 +16,7 @@ import { ShelterService } from './shelter.service';
 import { ServerResponse } from '../utils';
 import { StaffGuard } from '@/guards/staff.guard';
 import { ApplyUser } from '@/guards/apply-user.guard';
-import { UserDecorator } from '@/decorators/UserDecorator';
+import { UserDecorator } from '@/decorators/UserDecorator/user.decorator';
 
 @ApiTags('Abrigos')
 @Controller('shelters')
@@ -40,7 +40,9 @@ export class ShelterController {
   @UseGuards(ApplyUser)
   async show(@UserDecorator() user: any, @Param('id') id: string) {
     try {
-      const data = await this.shelterService.show(id, user);
+      const isLogged =
+        Boolean(user) && Boolean(user?.sessionId) && Boolean(user?.userId);
+      const data = await this.shelterService.show(id, isLogged);
       return new ServerResponse(200, 'Successfully get shelter', data);
     } catch (err: any) {
       this.logger.error(`Failed to get shelter: ${err}`);

--- a/src/shelter/shelter.controller.ts
+++ b/src/shelter/shelter.controller.ts
@@ -15,6 +15,8 @@ import { ApiTags } from '@nestjs/swagger';
 import { ShelterService } from './shelter.service';
 import { ServerResponse } from '../utils';
 import { StaffGuard } from '@/guards/staff.guard';
+import { ApplyUser } from '@/guards/apply-user.guard';
+import { UserDecorator } from '@/decorators/UserDecorator';
 
 @ApiTags('Abrigos')
 @Controller('shelters')
@@ -35,9 +37,10 @@ export class ShelterController {
   }
 
   @Get(':id')
-  async show(@Param('id') id: string) {
+  @UseGuards(ApplyUser)
+  async show(@UserDecorator() user: any, @Param('id') id: string) {
     try {
-      const data = await this.shelterService.show(id);
+      const data = await this.shelterService.show(id, user);
       return new ServerResponse(200, 'Successfully get shelter', data);
     } catch (err: any) {
       this.logger.error(`Failed to get shelter: ${err}`);

--- a/src/shelter/shelter.service.ts
+++ b/src/shelter/shelter.service.ts
@@ -60,10 +60,7 @@ export class ShelterService {
     });
   }
 
-  async show(id: string, user: any) {
-    const isLogged =
-      Boolean(user) && Boolean(user?.sessionId) && Boolean(user?.userId);
-
+  async show(id: string, shouldShowContact: boolean) {
     const data = await this.prismaService.shelter.findFirst({
       where: {
         id,
@@ -75,7 +72,7 @@ export class ShelterService {
         pix: true,
         shelteredPeople: true,
         capacity: true,
-        contact: isLogged,
+        contact: shouldShowContact,
         petFriendly: true,
         prioritySum: true,
         latitude: true,

--- a/src/shelter/shelter.service.ts
+++ b/src/shelter/shelter.service.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { Injectable } from '@nestjs/common';
 import * as qs from 'qs';
-import { Prisma } from '@prisma/client';
+import { Prisma, AccessLevel } from '@prisma/client';
 import { DefaultArgs } from '@prisma/client/runtime/library';
 
 import { PrismaService } from '../prisma/prisma.service';
@@ -14,6 +14,7 @@ import { SearchSchema } from '../types';
 import { ShelterSearch, parseTagResponse } from './ShelterSearch';
 import { SupplyPriority } from '../supply/types';
 import { IFilterFormProps } from './types/search.types';
+import { isRightSessionRole } from '@/guards/utils';
 
 @Injectable()
 export class ShelterService {
@@ -60,7 +61,13 @@ export class ShelterService {
     });
   }
 
-  async show(id: string) {
+  async show(id: string, user: any) {
+    const isLogged = await isRightSessionRole(
+      [AccessLevel.User, AccessLevel.Staff],
+      user?.sessionId,
+      user?.userId,
+    );
+
     const data = await this.prismaService.shelter.findFirst({
       where: {
         id,
@@ -72,7 +79,7 @@ export class ShelterService {
         pix: true,
         shelteredPeople: true,
         capacity: true,
-        contact: true,
+        contact: isLogged,
         petFriendly: true,
         prioritySum: true,
         latitude: true,

--- a/src/shelter/shelter.service.ts
+++ b/src/shelter/shelter.service.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { Injectable } from '@nestjs/common';
 import * as qs from 'qs';
-import { Prisma, AccessLevel } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { DefaultArgs } from '@prisma/client/runtime/library';
 
 import { PrismaService } from '../prisma/prisma.service';
@@ -14,7 +14,6 @@ import { SearchSchema } from '../types';
 import { ShelterSearch, parseTagResponse } from './ShelterSearch';
 import { SupplyPriority } from '../supply/types';
 import { IFilterFormProps } from './types/search.types';
-import { isRightSessionRole } from '@/guards/utils';
 
 @Injectable()
 export class ShelterService {
@@ -62,11 +61,8 @@ export class ShelterService {
   }
 
   async show(id: string, user: any) {
-    const isLogged = await isRightSessionRole(
-      [AccessLevel.User, AccessLevel.Staff],
-      user?.sessionId,
-      user?.userId,
-    );
+    const isLogged =
+      Boolean(user) && Boolean(user?.sessionId) && Boolean(user?.userId);
 
     const data = await this.prismaService.shelter.findFirst({
       where: {

--- a/src/shelter/shelter.service.ts
+++ b/src/shelter/shelter.service.ts
@@ -144,7 +144,6 @@ export class ShelterService {
         pix: true,
         address: true,
         capacity: true,
-        contact: true,
         petFriendly: true,
         shelteredPeople: true,
         prioritySum: true,

--- a/src/shelter/types/search.types.ts
+++ b/src/shelter/types/search.types.ts
@@ -12,7 +12,9 @@ export interface IFilterFormProps {
   tags: ShelterTagInfo | null;
 }
 
-export type SearchShelterTagResponse = Shelter & {
+type AllowedShelterFields = Omit<Shelter, 'contact'>;
+
+export type SearchShelterTagResponse = AllowedShelterFields & {
   shelterSupplies: (ShelterSupply & { supply: Supply })[];
 };
 


### PR DESCRIPTION
## Descrição
É necessário ocultar o dado de contato(telefone) para o público em geral e restringir para apenas usuários(`STAFF` e `USER`) para controlar melhor quem visualiza e deixar apenas para pessoal capacitado(registrado).

## Solução
Como as guards atuais no `controller`(como `@UseGuards(UserGuard)`) restrigem totalmente o acesso a aquela rota para usuários registrados foi preciso
1. Fazer um decorator(para interceptar a request) para pegar o contexto e retornar o usuário(caso tenha)
2. Fazer uma guard para repassar o usuário para o controller
3. No controller pegar o usuário e repassar para o service
4. ~Então passar para uma função para verificar se o usuário(caso esteja logado) seja um dos permitidos(no momento todos)~ Basta verificar se um usuário é passado no guards(verificar se recebe do contexto de guard `user`, `userId` e `sessionId`)
5. Caso seja então retorna o `contact`

## Testes
É preciso fazer uns testes já que modifica alguns pontos e pode quebrar outros. Apesar de testar localmente e não ter quebrado nada os casos recomendados(mais impactados) foram:
 - [x] (Logado) Testar no frontend detalhe de um abrigo: deve aparecer o contato
 - [x] (Não Logado) Testar no frontend detalhe de um abrigo: **não** deve aparecer o contato