### PR TITLE
update: easier docker dump instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Se estiver usando Docker, os comandos para carregar o dump são:
 
 ```bash
 # Copiar o dump para a pasta temporária do Docker
-docker exec -it cp backup.sql POSTGRES_CONTAINER_ID:/tmp/backup.sql
+docker cp ./prisma/dev_dump.sql sos-rs-db:/tmp/backup.sql
 # Importar o dump para o banco
-docker exec -i POSTGRES_CONTAINER_ID psql -U root -d DATABASE_NAME -f /tmp/backup.sql
+docker exec -i sos-rs-db psql -U root -d sos_rs -f /tmp/backup.sql
 ```
 
 ## 🐳 Configuração com Docker

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Discord [aqui](https://discord.gg/vjZS6BQXvM).
 
 ## 🗂 Dump do Banco de Dados
 
-Para iniciar com dados de exemplo, utilize o dump do banco disponível em `prisma/migration/dev_dump.sql`. Este arquivo
+Para iniciar com dados de exemplo, utilize o dump do banco disponível em `prisma/dev_dump.sql`. Este arquivo
 pode ser executado após as migrations estarem aplicadas.
 
 Se estiver usando Docker, os comandos para carregar o dump são:


### PR DESCRIPTION
Eu tive dificuldades de executar o dump do SQL dentro do docker localmente e vi que o primeiro comando estava usando docker exec ao invés de db. Conforme a documentação do docker no caso de copiar arquivos para dentro do docker se usa 'docker cp' apenas, seguido do arquivo a ser copiado e por fim para onde copiar.

Como forma de melhorar ainda mais as instruções, @lucaskdc sugeriu uma versão genérica do comando na issue https://github.com/SOS-RS/backend/issues/109