### PR TITLE
fix: city filter

### DIFF
--- a/src/shelter/shelter.service.ts
+++ b/src/shelter/shelter.service.ts
@@ -187,6 +187,11 @@ export class ShelterService implements OnModuleInit {
 
   async getCities() {
     const cities = await this.prismaService.shelter.groupBy({
+      where: {
+        city: {
+          not: null,
+        },
+      },
       by: ['city'],
       _count: {
         id: true,
@@ -198,12 +203,10 @@ export class ShelterService implements OnModuleInit {
       },
     });
 
-    return cities
-      .filter((c) => c.city)
-      .map(({ city, _count: { id: sheltersCount } }) => ({
-        city,
-        sheltersCount,
-      }));
+    return cities.map(({ city, _count: { id: sheltersCount } }) => ({
+      city,
+      sheltersCount,
+    }));
   }
 
   private loadVoluntaryIds() {

--- a/src/shelter/shelter.service.ts
+++ b/src/shelter/shelter.service.ts
@@ -198,10 +198,12 @@ export class ShelterService implements OnModuleInit {
       },
     });
 
-    return cities.map(({ city, _count: { id: sheltersCount } }) => ({
-      city: city || 'Cidade não informada',
-      sheltersCount,
-    }));
+    return cities
+      .filter((c) => c.city)
+      .map(({ city, _count: { id: sheltersCount } }) => ({
+        city,
+        sheltersCount,
+      }));
   }
 
   private loadVoluntaryIds() {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -26,7 +26,10 @@ export class UsersController {
   @Post('')
   @UseGuards(AdminGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Cria um novo usuário', description: 'Esta rota é usada para criar um novo usuário no sistema.' })
+  @ApiOperation({
+    summary: 'Cria um novo usuário',
+    description: 'Esta rota é usada para criar um novo usuário no sistema.',
+  })
   @ApiBody({
     schema: {
       type: 'object',
@@ -60,7 +63,11 @@ export class UsersController {
   @Put(':id')
   @UseGuards(AdminGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Atualiza um usuário pelo ID', description: 'Esta rota é usada para atualizar um usuário específico no sistema, podendo ser informado um ou mais campos.' })
+  @ApiOperation({
+    summary: 'Atualiza um usuário pelo ID',
+    description:
+      'Esta rota é usada para atualizar um usuário específico no sistema, podendo ser informado um ou mais campos.',
+  })
   @ApiBody({
     schema: {
       type: 'object',
@@ -98,7 +105,11 @@ export class UsersController {
   @Put('')
   @UseGuards(UserGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Atualiza o seu próprio usuário', description: 'Esta rota é usada para atualizar o próprio usuário no sistema, podendo ser informado um ou mais campos.' })
+  @ApiOperation({
+    summary: 'Atualiza o seu próprio usuário',
+    description:
+      'Esta rota é usada para atualizar o próprio usuário no sistema, podendo ser informado um ou mais campos.',
+  })
   @ApiBody({
     schema: {
       type: 'object',


### PR DESCRIPTION
**O que?**
Removido as cidades nulas da lista de cidades retornada pelo endpoint GET shelter/cities.

**Por que?**
As cidades estavam vindo com o nome default de "Cidade não informada" quando ela possuia com campo city NULO no banco de dados. E esse comportamento estava fazendo aparecer no select do frontend inúmeras "cidade não informada". Quando usado uma cidade cujo nome era "Cidade não informada" no filtro e buscado na api, nao era retornado nenhum resultado, sendo que o comportamento esperado era não buscar por cidade específica já que a cidade não foi informada.

**Como?**
Adicionado uma clausula Where no filtro de cidades onde ele busca apenas os registros que possuem a coluna city como NOT NULL.