### PR TITLE
hotfix: added in admin update shelter transform to remove empty strin…

### DIFF
--- a/src/shelter/types/types.ts
+++ b/src/shelter/types/types.ts
@@ -1,6 +1,7 @@
 import z from 'zod';
 
 import { capitalize } from '../../utils';
+import { removeEmptyStrings } from '@/utils/utils';
 
 export interface DefaultSupplyProps {
   category: string;
@@ -44,7 +45,9 @@ const FullUpdateShelterSchema = ShelterSchema.omit({
   id: true,
   createdAt: true,
   updatedAt: true,
-}).partial();
+})
+  .partial()
+  .transform(removeEmptyStrings);
 
 export {
   ShelterSchema,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -110,6 +110,13 @@ function calculateGeolocationBounds({
   };
 }
 
+function removeEmptyStrings(obj: Record<string, any>): Record<string, any> {
+  return Object.entries(obj).reduce(
+    (prev, [key, value]) => (value === '' ? prev : { ...prev, [key]: value }),
+    {},
+  );
+}
+
 export {
   ServerResponse,
   calculateGeolocationBounds,
@@ -117,4 +124,5 @@ export {
   deepMerge,
   getSessionData,
   removeNotNumbers,
+  removeEmptyStrings,
 };


### PR DESCRIPTION
Quando um usuário logado com permissão de Admin tenta editar um abrigo e deixar o pix vazio, ele recebe um erro da api indicando que já existe cadastrado o pix -> "".  

Para isso criei uma função para usar na validação de schema do zod que converte todos campos que são strings vazios em undefined, e dessa forma o erro não irá mais acontecer.

Essa função poderá ser usado em outros casos que percebermos o mesmo comportamento.