### PR TITLE
fix: Abrigos com capacidade igual a 0 não estão sendo exibidos na busca.

### DIFF
--- a/src/shelter/ShelterSearch.ts
+++ b/src/shelter/ShelterSearch.ts
@@ -54,7 +54,7 @@ class ShelterSearch {
       ShelterStatus,
       Prisma.ShelterWhereInput['capacity'] | null
     > = {
-      waiting: null,
+      waiting: null || 0,
       available: {
         gt: this.prismaService.shelter.fields.shelteredPeople,
       },


### PR DESCRIPTION
Com a remoção dessa alteração do PR #105, gerou-se um novo problema. Os abrigos com o campo capacity igual a zero não terão status e consequentemente não aparecerão nas buscas. Isso é um problema grave, visto que há muitos assim na base e que agora eles não estão aparecendo para a população. Peço que reconsidere essa alteração.