### PR TITLE
Não publicar em forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'SOS-RS/backend'
     runs-on: self-hosted
 
     steps:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'SOS-RS/backend'
     runs-on: dev
 
     steps:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'SOS-RS/backend'
     runs-on: stg
 
     steps:


### PR DESCRIPTION
Com esse filtro evitamos que os workflows rodem nos forks.