### PR TITLE
feat: added decay shelter supply behaviour

### DIFF
--- a/src/interceptors/interceptors/shelter-supply-history/shelter-supply-history.interceptor.ts
+++ b/src/interceptors/interceptors/shelter-supply-history/shelter-supply-history.interceptor.ts
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs';
 
 import { ShelterSupplyHistoryAction } from './types';
 import { handler } from './utils';
-import { prisma } from '../../../prisma/prisma.service';
+import { PrismaService } from '../../../prisma/prisma.service';
 
 @Injectable()
 export class ShelterSupplyHistoryInterceptor implements NestInterceptor {
@@ -16,7 +16,7 @@ export class ShelterSupplyHistoryInterceptor implements NestInterceptor {
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const request = context.switchToHttp().getRequest();
-    handler(prisma, this.action, request);
+    handler(PrismaService.getInstance(), this.action, request);
     return next.handle();
   }
 }

--- a/src/interceptors/interceptors/shelter-supply-history/utils.ts
+++ b/src/interceptors/interceptors/shelter-supply-history/utils.ts
@@ -14,15 +14,14 @@ import { ShelterSupplyHistoryAction, UserIdentity } from './types';
 import { getSessionData } from '@/utils/utils';
 
 function registerSupplyLog(
-  prismaService: PrismaService,
   body: z.infer<typeof CreateSupplyHistorySchema>,
-  user: UserIdentity,
+  user: UserIdentity = {},
 ) {
   const fn = async () => {
     const { shelterId, supplyId, ...rest } =
       CreateSupplyHistorySchema.parse(body);
 
-    const prev = await prismaService.supplyHistory.findFirst({
+    const prev = await PrismaService.getInstance().supplyHistory.findFirst({
       where: {
         shelterId,
         supplyId,
@@ -32,7 +31,7 @@ function registerSupplyLog(
       },
     });
 
-    await prismaService.supplyHistory.create({
+    await PrismaService.getInstance().supplyHistory.create({
       data: {
         shelterId,
         supplyId,
@@ -57,23 +56,20 @@ function registerSupplyLog(
 }
 
 function registerCreateSupplyLog(
-  prismaService: PrismaService,
   body: z.infer<typeof CreateShelterSupplySchema>,
   user: UserIdentity,
 ) {
   const payload = CreateShelterSupplySchema.parse(body);
-  registerSupplyLog(prismaService, payload, user);
+  registerSupplyLog(payload, user);
 }
 
 function registerUpdateSupplyLog(
-  prismaService: PrismaService,
   body: z.infer<typeof UpdateShelterSupplySchema>,
   user: UserIdentity,
 ) {
   const payload = UpdateShelterSupplySchema.parse(body);
 
   registerSupplyLog(
-    prismaService,
     {
       shelterId: payload.where.shelterId,
       supplyId: payload.where.supplyId,
@@ -85,7 +81,6 @@ function registerUpdateSupplyLog(
 }
 
 function registerUpdateManySupplyLog(
-  prismaService: PrismaService,
   body: z.infer<typeof UpdateManyShelterSupplySchema>,
   user: UserIdentity,
 ) {
@@ -93,7 +88,6 @@ function registerUpdateManySupplyLog(
 
   ids.forEach((id) =>
     registerSupplyLog(
-      prismaService,
       {
         shelterId,
         supplyId: id,
@@ -124,11 +118,10 @@ function handler(
 
   switch (action) {
     case ShelterSupplyHistoryAction.Create:
-      registerCreateSupplyLog(prismaService, request.body as any, user);
+      registerCreateSupplyLog(request.body as any, user);
       break;
     case ShelterSupplyHistoryAction.Update:
       registerUpdateSupplyLog(
-        prismaService,
         {
           data: request.body as any,
           where: request.params as any,
@@ -138,7 +131,6 @@ function handler(
       break;
     case ShelterSupplyHistoryAction.UpdateMany:
       registerUpdateManySupplyLog(
-        prismaService,
         {
           shelterId: (request.params as any).shelterId,
           ids: (request.body as any).ids,
@@ -149,4 +141,4 @@ function handler(
   }
 }
 
-export { handler };
+export { handler, registerSupplyLog };

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -39,5 +39,3 @@ export class PrismaService
     });
   }
 }
-
-export const prisma = PrismaService.getInstance();

--- a/src/shelter/types/types.ts
+++ b/src/shelter/types/types.ts
@@ -49,6 +49,14 @@ const FullUpdateShelterSchema = ShelterSchema.omit({
   .partial()
   .transform((args) => removeEmptyStrings<typeof args>(args));
 
+export interface IShelterSupplyDecay {
+  shelterId: string;
+  supplyId: string;
+  priority: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
 export {
   ShelterSchema,
   CreateShelterSchema,


### PR DESCRIPTION
- Adicionado o decaimento das prioridades dos suprimentos para incentivar o usuário a atualizar os dados e para evitar dados desatualizados na base.

Foi utilizado os seguintes critérios:

- Caso o suprimento seja de prioridade `Urgent` (máxima) e não é atualizado a mais de 12 horas, ele é atualizado para o status de `Needing`. 

- Caso o suprimento seja de prioridade `Needing` ou `Remaining` e não é atualizado a mais de 48 horas, sua prioridade é atualizada para sob controle.

Além disso é salvo todos os logs do shelter supplies conforme já implementado nos endpoints de update.

--

Foi escolhido a estratégia de aproveitar o retorno da lista de abrigo e de abrigos únicos para obter a lista de suprimentos ao invés de rodar um schedule que sempre percorre inteiramente o banco de dados. Dessa forma essas atualizações serão por demanda.