### PR TITLE
Feat/handle duplicated supplies #Issue 179

### DIFF
--- a/src/supply-categories/supply-categories.controller.ts
+++ b/src/supply-categories/supply-categories.controller.ts
@@ -43,12 +43,19 @@ export class SupplyCategoriesController {
   @UseGuards(AdminGuard)
   async store(@Body() body) {
     try {
+      const isDuplicate = await this.supplyCategoryServices.isDuplicate(body);
+
+      if (isDuplicate) {
+        return new ServerResponse(400, 'This category already exists')
+      }
+
       const data = await this.supplyCategoryServices.store(body);
       return new ServerResponse(
         200,
         'Successfully created supply category',
         data,
       );
+      
     } catch (err: any) {
       this.logger.error(`Failed to create supply category: ${err}`);
       throw new HttpException(err?.code ?? err?.name ?? `${err}`, 400);

--- a/src/supply-categories/supply-categories.service.spec.ts
+++ b/src/supply-categories/supply-categories.service.spec.ts
@@ -4,22 +4,34 @@ import { SupplyCategoriesService } from './supply-categories.service';
 
 describe('SupplyCategoriesService', () => {
   let service: SupplyCategoriesService;
+  let prisma: PrismaService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [SupplyCategoriesService],
-    })
-      .useMocker((token) => {
-        if (token === PrismaService) {
-          return {};
-        }
-      })
-      .compile();
+      providers: [SupplyCategoriesService, PrismaService],
+    }).compile();
 
     service = module.get<SupplyCategoriesService>(SupplyCategoriesService);
+    prisma = module.get<PrismaService>(PrismaService);
+    prisma.supplyCategory.findFirst = jest.fn(); // Adicione esta linha
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should check for duplicates', async () => {
+    const body = {
+      name: 'Test',
+    };
+
+    const mockSupply = {
+      name: 'Test'
+    } as any;
+
+    jest.spyOn(prisma.supplyCategory, 'findFirst').mockResolvedValue(mockSupply);
+
+    const result = await service.isDuplicate(body);
+    expect(result).toBe(true);
   });
 });

--- a/src/supply-categories/supply-categories.service.ts
+++ b/src/supply-categories/supply-categories.service.ts
@@ -7,6 +7,8 @@ import {
   UpdateSupplyCategorySchema,
 } from './types';
 
+import { slugify } from '@/utils/utils';
+
 @Injectable()
 export class SupplyCategoriesService {
   constructor(private readonly prismaService: PrismaService) {}
@@ -38,9 +40,25 @@ export class SupplyCategoriesService {
     return await this.prismaService.supplyCategory.findMany({});
   }
 
-  async isDuplicate(body: z.infer<typeof CreateSupplyCategorySchema>) : boolean {
+  async isDuplicate(body: z.infer<typeof CreateSupplyCategorySchema>) : Promise<boolean> {
 
-    const existingData = return await this.prismaService.supplyCategory.findMany({});
+    const payload = CreateSupplyCategorySchema.parse(body);
+    const existingData = await this.prismaService.supplyCategory.findFirst({
+      where: {
+        name: payload.name
+      },
+      select: {
+        name: true,
+      },
+    });
 
+    const payloadName = slugify(payload.name)
+    const existingDataName = slugify(existingData?.name)
+
+    if (payloadName === existingDataName) {
+      return true
+    }
+
+    return false
   }
 }

--- a/src/supply-categories/supply-categories.service.ts
+++ b/src/supply-categories/supply-categories.service.ts
@@ -37,4 +37,10 @@ export class SupplyCategoriesService {
   async index() {
     return await this.prismaService.supplyCategory.findMany({});
   }
+
+  async isDuplicate(body: z.infer<typeof CreateSupplyCategorySchema>) : boolean {
+
+    const existingData = return await this.prismaService.supplyCategory.findMany({});
+
+  }
 }

--- a/src/supply/supply.controller.ts
+++ b/src/supply/supply.controller.ts
@@ -33,9 +33,17 @@ export class SupplyController {
 
   @Post('')
   async store(@Body() body) {
-    try {
+    try { 
+      
+      const isDuplicate = await this.supplyServices.isDuplicate(body);
+
+      if (isDuplicate) {
+        return new ServerResponse(400, 'This supply already exists')
+      }
+
       const data = await this.supplyServices.store(body);
       return new ServerResponse(200, 'Successfully created supply', data);
+
     } catch (err: any) {
       this.logger.error(`Failed to create supply: ${err}`);
       throw new HttpException(err?.code ?? err?.name ?? `${err}`, 400);

--- a/src/supply/supply.service.spec.ts
+++ b/src/supply/supply.service.spec.ts
@@ -4,22 +4,38 @@ import { PrismaService } from 'src/prisma/prisma.service';
 
 describe('SupplyService', () => {
   let service: SupplyService;
+  let prisma: PrismaService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [SupplyService],
-    })
-      .useMocker((token) => {
-        if (token === PrismaService) {
-          return {};
-        }
-      })
-      .compile();
+      providers: [SupplyService, PrismaService],
+    }).compile();
 
     service = module.get<SupplyService>(SupplyService);
+    prisma = module.get<PrismaService>(PrismaService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
+
+  it('should check for duplicates', async () => {
+    const body = {
+      name: 'Test',
+      supplyCategoryId: '1',
+    };
+
+    const mockSupply = {
+      name: 'Test',
+      supplyCategory: {
+        id: '1',
+      },
+    } as any;
+  
+    jest.spyOn(prisma.supply, 'findFirst').mockResolvedValue(mockSupply);
+
+    const result = await service.isDuplicate(body);
+    expect(result).toBe(true);
+  });
+
 });

--- a/src/supply/supply.service.ts
+++ b/src/supply/supply.service.ts
@@ -58,7 +58,14 @@ export class SupplyService {
   }
 
   async isDuplicate(body: z.infer<typeof CreateSupplySchema>):Promise<boolean> {
+
+    const payload = CreateSupplySchema.parse(body);
+    const payloadName = slugify(payload.name)
+
     const existingData = await this.prismaService.supply.findFirst({
+      where: {
+        name: payload.name
+      },
       select: {
         name: true,
         supplyCategory: {
@@ -69,9 +76,6 @@ export class SupplyService {
       },
     });
     const existingDataName = slugify(existingData?.name)
-
-    const payload = CreateSupplySchema.parse(body);
-    const payloadName = slugify(payload.name)
 
     if (existingDataName === payloadName
       && payload.supplyCategoryId === existingData?.supplyCategory.id) {

--- a/src/supply/supply.service.ts
+++ b/src/supply/supply.service.ts
@@ -4,6 +4,8 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateSupplySchema, UpdateSupplySchema } from './types';
 
+import { slugify } from '@/utils/utils';
+
 @Injectable()
 export class SupplyService {
   constructor(private readonly prismaService: PrismaService) {}
@@ -56,26 +58,14 @@ export class SupplyService {
   }
 
   async isDuplicate(body: z.infer<typeof CreateSupplySchema>):Promise<boolean> {
-
-    function slugify(name: string | void):string {
-
-      const slugName = String(name).normalize('NFKD').replace(/[\u0300-\u036f]/g, '').trim().toLowerCase()
-      .replace(/[^a-z0-9 -]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-')
-      return slugName
-    }
-
     const existingData = await this.prismaService.supply.findFirst({
       select: {
-        id: false,
         name: true,
         supplyCategory: {
           select: {
             id: true,
-            name: false,
           },
         },
-        createdAt: false,
-        updatedAt: false,
       },
     });
     const existingDataName = slugify(existingData?.name)
@@ -90,4 +80,5 @@ export class SupplyService {
 
     return false;
   }
+
 }

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { slugify } from './utils';
+
+describe('slugify function', () => {
+
+    it('should handle accented characters', () => {
+      const result = slugify('tést');
+      expect(result).toBe('test');
+    });
+
+    it('should handle uppercase characters', () => {
+      const result = slugify('Test');
+      expect(result).toBe('test');
+    });
+
+    it('should handle double spaces', () => {
+      const result = slugify('test  test');
+      expect(result).toBe('test-test');
+    });
+});

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -119,9 +119,9 @@ function removeEmptyStrings<T>(obj): T {
 
 function slugify(str:string | void):string {
 
-  const slugfied = String(str).normalize('NFKD').replace(/[\u0300-\u036f]/g, '').trim().toLowerCase()
+  const slugified = String(str).normalize('NFKD').replace(/[\u0300-\u036f]/g, '').trim().toLowerCase()
   .replace(/[^a-z0-9 -]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-')
-  return slugfied
+  return slugified
 
 }
 export {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -117,6 +117,13 @@ function removeEmptyStrings<T>(obj): T {
   ) as T;
 }
 
+function slugify(str:string | void):string {
+
+  const slugfied = String(str).normalize('NFKD').replace(/[\u0300-\u036f]/g, '').trim().toLowerCase()
+  .replace(/[^a-z0-9 -]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-')
+  return slugfied
+
+}
 export {
   ServerResponse,
   calculateGeolocationBounds,
@@ -125,4 +132,5 @@ export {
   getSessionData,
   removeNotNumbers,
   removeEmptyStrings,
+  slugify
 };


### PR DESCRIPTION
Issue: #179 

 Criei services de validação para verificar a inclusão de itens duplicados em supply e suplly category.
 
 Criei uma função slugify em utils para normalizar os nomes antes da comparação.
 
 Não criei uma query para remover dados duplicados do DB, pois existem itens associados a eles no history e os supplies já estão sendo filtrados por um select distincs no service index()
 
 Criei testes correspondentes às funcionalidades implementadas.